### PR TITLE
Go 1.6 support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ SCRIPT
 
 Vagrant.configure('2') do |config|
   config.vm.box = "obc/dev-env"
-  config.vm.box_version = ENV['USE_LOCAL_OBC_BASEIMAGE'] ? "0":"0.2.0" # Vagrant does not support versioning local images, the local version is always implicitly version 0
+  config.vm.box_version = ENV['USE_LOCAL_OBC_BASEIMAGE'] ? "0":"0.2.1" # Vagrant does not support versioning local images, the local version is always implicitly version 0
 
   config.vm.network :forwarded_port, guest: 5000, host: 3000 # Openchain REST services
 

--- a/baseimage/installGolang.sh
+++ b/baseimage/installGolang.sh
@@ -29,7 +29,7 @@ SRCPATH=$GOPATH
 
 #ARCH=`uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|'`
 ARCH=amd64
-GO_VER=1.5.1
+GO_VER=1.6
 
 cd /tmp
 rm -f go$GO_VER.linux-${ARCH}.tar.gz

--- a/installGolang.sh
+++ b/installGolang.sh
@@ -37,7 +37,6 @@ sudo chown -R vagrant:vagrant $GOPATH
 cat <<EOF >/tmp/gopath.sh
 export GOPATH="$GOPATH"
 export GOROOT="$GOROOT"
-export GO15VENDOREXPERIMENT=1
 export PATH="$GOROOT/bin:$GOPATH/bin:\$PATH"
 export CGO_CFLAGS="-I/opt/rocksdb/include"
 export CGO_LDFLAGS="-L/opt/rocksdb -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy"

--- a/setup.sh
+++ b/setup.sh
@@ -93,7 +93,6 @@ pip install -I flask==0.10.1 python-dateutil==2.2 pytz==2014.3 pyyaml==3.10 couc
 # Set Go environment variables needed by other scripts
 export GOPATH="/opt/gopath"
 export GOROOT="/opt/go/"
-export GO15VENDOREXPERIMENT=1
 PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 
 #install golang deps


### PR DESCRIPTION
For issue #37. Moves vagrant image to Go 1.6 and removes experimental vendor flag.

Signed-off-by: <sheehan@us.ibm.com>